### PR TITLE
Add some missing dependencies for openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Fedora  / Red Hat:
 	sudo dnf install make gcc python3 audiofile-devel glew-devel SDL2-devel zstd zenity g++
 openSuSE:
 
-	sudo zypper in gcc make python3 libaudiofile1 glew-devel libSDL2-devel zenity
+	sudo zypper in gcc make python3 glew-devel libSDL2-devel zenity libzstd-devel audiofile-devel
 Solus:
 	
 	sudo eopkg install make gcc python3 audiofile-devel glew-devel sdl2-devel zenity


### PR DESCRIPTION
libzstd-devel and audiofile-devel are needed to build sm64nx on OpenSUSE. libaudiofile1 is pulled in by audiofile-devel, so it does not need to be installed separately.